### PR TITLE
Handle jsbsim bridge configurations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ include_directories(include)
 
 add_executable(jsbsim_bridge
 			   src/main.cpp
+			   src/configuration_parser.cpp
 			   src/jsbsim_bridge.cpp
 			   src/geo_mag_declination.cpp
 			   src/mavlink_interface.cpp

--- a/configs/rascal.xml
+++ b/configs/rascal.xml
@@ -1,4 +1,8 @@
 <model name="rascal">
+    <jsbsimbridge>
+        <aircraft_directory>models/Rascal</aircraft_directory>
+        <aircraft_model>Rascal110-JSBSim</aircraft_model>
+    </jsbsimbridge>
     <mavlink_interface>
         <tcp_port>4560</tcp_port>
     </mavlink_interface>

--- a/include/common.h
+++ b/include/common.h
@@ -41,6 +41,7 @@
 
 #pragma once
 
+#include <tinyxml.h>
 #include <cmath>
 
 inline double ftToM(double ft) { return 0.3048 * ft; }
@@ -57,4 +58,91 @@ inline double wrap_pi(double x) {
   }
 
   return x;
+}
+
+inline bool CheckConfigElement(const TiXmlElement &config, std::string param) {
+  const TiXmlElement *e = config.FirstChildElement(param);
+  return e != nullptr;
+}
+
+inline bool CheckConfigElement(const TiXmlHandle &config, std::string group, std::string param) {
+  const TiXmlElement *group_element = config.FirstChild(group).Element();
+  if (!group_element) {
+    return false;
+  }
+
+  const TiXmlElement *e = group_element->FirstChildElement(param);
+  return e != nullptr;
+}
+
+inline TiXmlElement GetXmlElement(const TiXmlHandle &config, std::string group, std::string param) {
+  const TiXmlElement *group_element = config.FirstChild(group).Element();
+  if (!group_element) {
+    return nullptr;
+  }
+
+  const TiXmlElement *e = group_element->FirstChildElement(param);
+  if (!e) {
+    return nullptr;
+  }
+  return *e;
+}
+
+template <typename T>
+bool GetConfigElement(const TiXmlHandle &config, const std::string &group, const std::string &param, T &param_value) {
+  const TiXmlElement *group_element = config.FirstChild(group).Element();
+  if (!group_element) {
+    return false;
+  }
+
+  const TiXmlElement *e = group_element->FirstChildElement(param);
+  if (e) {
+    std::istringstream iss(e->GetText());
+    iss >> param_value;
+    return true;
+  }
+  return false;
+}
+
+template <typename T>
+bool GetConfigElement(const TiXmlElement &element, const std::string &param, T &param_value) {
+  const TiXmlElement *e = element.FirstChildElement(param);
+  if (e) {
+    std::istringstream iss(e->GetText());
+    iss >> param_value;
+    return true;
+  }
+  return false;
+}
+
+template <typename T>
+bool GetConfigElement(const TiXmlElement &config, const std::string &group, const std::string &param, T &param_value) {
+  const TiXmlElement *group_element = config.FirstChildElement(group);
+  if (!group_element) {
+    return false;
+  }
+
+  const TiXmlElement *e = group_element->FirstChildElement(param);
+  if (e) {
+    std::istringstream iss(e->GetText());
+    iss >> param_value;
+    return true;
+  }
+  return false;
+}
+
+inline bool GetConfigElement(const TiXmlHandle &config, const std::string &group, const std::string &param,
+                             bool &param_value) {
+  const TiXmlElement *group_element = config.FirstChild(group).Element();
+  if (!group_element) {
+    return false;
+  }
+
+  const TiXmlElement *e = group_element->FirstChildElement(param);
+  if (e) {
+    std::istringstream iss(e->GetText());
+    iss >> std::boolalpha >> param_value;
+    return true;
+  }
+  return false;
 }

--- a/include/configuration_parser.h
+++ b/include/configuration_parser.h
@@ -31,30 +31,38 @@
  *
  ****************************************************************************/
 /**
- * @brief JSBSim Airspeed Plugin
+ * @brief JSBSim Bridge Configuration Parser
  *
- * This is a plugin modeling a airspeed sensor for JSBSim
+ * This is a class for the JSBSim actuator plugin
  *
  * @author Jaeyoung Lim <jaeyoung@auterion.com>
- * @author Roman Bapst <roman@auterion.com>
  */
 
 #pragma once
 
 #include "common.h"
-#include "sensor_plugin.h"
 
-class SensorAirspeedPlugin : public SensorPlugin {
+#include <memory>
+#include <tinyxml.h>
+#include <Eigen/Eigen>
+
+class ConfigurationParser {
  public:
-  SensorAirspeedPlugin(JSBSim::FGFDMExec* jsbsim);
-  ~SensorAirspeedPlugin();
-  void setSensorConfigs(const TiXmlElement& configs);
-  SensorData::Airspeed getData();
+  ConfigurationParser() = default;
+  ~ConfigurationParser() = default;
+  bool ParseEnvironmentVariables();
+  bool ParseConfigFile(const std::string& path);
+  bool ParseArgV(int argc, char* const argv[]);
+  inline bool isHeadless() { return _headless; }
+  inline std::shared_ptr<TiXmlHandle> XmlHandle() { return _config; }
+  inline std::string getInitScriptPath() { return _init_script_path; }
+  inline std::string getModelName() { return _model_name; }
 
  private:
-  double getAirspeed();
-  double getAirTemperature();
+  TiXmlDocument _doc;
+  std::shared_ptr<TiXmlHandle> _config;
 
-  std::normal_distribution<double> standard_normal_distribution_;
-  double _diff_pressure_stddev{0.01};
+  bool _headless{false};
+  std::string _init_script_path;
+  std::string _model_name;
 };

--- a/include/jsbsim_bridge.h
+++ b/include/jsbsim_bridge.h
@@ -43,6 +43,7 @@
 #include "mavlink_interface.h"
 
 #include "actuator_plugin.h"
+#include "configuration_parser.h"
 #include "sensor_airspeed_plugin.h"
 #include "sensor_baro_plugin.h"
 #include "sensor_gps_plugin.h"
@@ -59,15 +60,16 @@ static constexpr int kDefaultSITLTcpPort = 4560;
 
 class JSBSimBridge {
  public:
-  JSBSimBridge(JSBSim::FGFDMExec *fdmexec, std::string &path);
+  JSBSimBridge(JSBSim::FGFDMExec *fdmexec, ConfigurationParser &cfg);
   ~JSBSimBridge();
   void Run();
 
  private:
-  bool CheckConfigElement(TiXmlHandle &config, std::string group, std::string name);
+  bool SetFdmConfigs(ConfigurationParser &cfg);
   bool SetMavlinkInterfaceConfigs(std::unique_ptr<MavlinkInterface> &interface, TiXmlHandle &config);
 
   JSBSim::FGFDMExec *_fdmexec;  // FDMExec pointer
+  ConfigurationParser &_cfg;
 
   std::unique_ptr<MavlinkInterface> _mavlink_interface;
   std::unique_ptr<SensorImuPlugin> _imu_sensor;

--- a/include/sensor_baro_plugin.h
+++ b/include/sensor_baro_plugin.h
@@ -46,8 +46,9 @@
 
 class SensorBaroPlugin : public SensorPlugin {
  public:
-  SensorBaroPlugin(JSBSim::FGFDMExec *jsbsim);
+  SensorBaroPlugin(JSBSim::FGFDMExec* jsbsim);
   ~SensorBaroPlugin();
+  void setSensorConfigs(const TiXmlElement& configs);
   SensorData::Barometer getData();
 
  private:

--- a/include/sensor_gps_plugin.h
+++ b/include/sensor_gps_plugin.h
@@ -46,8 +46,9 @@
 
 class SensorGpsPlugin : public SensorPlugin {
  public:
-  SensorGpsPlugin(JSBSim::FGFDMExec *jsbsim);
+  SensorGpsPlugin(JSBSim::FGFDMExec* jsbsim);
   ~SensorGpsPlugin();
+  void setSensorConfigs(const TiXmlElement& configs);
   SensorData::Gps getData();
 
  private:

--- a/include/sensor_imu_plugin.h
+++ b/include/sensor_imu_plugin.h
@@ -61,6 +61,7 @@ class SensorImuPlugin : public SensorPlugin {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   SensorImuPlugin(JSBSim::FGFDMExec* jsbsim);
   ~SensorImuPlugin();
+  void setSensorConfigs(const TiXmlElement& configs);
   SensorData::Imu getData();
 
  private:

--- a/include/sensor_mag_plugin.h
+++ b/include/sensor_mag_plugin.h
@@ -57,6 +57,7 @@ class SensorMagPlugin : public SensorPlugin {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   SensorMagPlugin(JSBSim::FGFDMExec* jsbsim);
   ~SensorMagPlugin();
+  void setSensorConfigs(const TiXmlElement& configs);
   SensorData::Magnetometer getData();
 
  private:

--- a/include/sensor_plugin.h
+++ b/include/sensor_plugin.h
@@ -50,6 +50,7 @@ class SensorPlugin {
  public:
   SensorPlugin(JSBSim::FGFDMExec *jsbsim);
   ~SensorPlugin();
+  virtual void setSensorConfigs(const TiXmlElement &configs) = 0;
   void setUpdateRate(double update_rate);
   bool updated();
 

--- a/src/configuration_parser.cpp
+++ b/src/configuration_parser.cpp
@@ -1,0 +1,89 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 Auterion AG. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @brief JSBSim Bridge Configuration Parser
+ *
+ * This is a class for the JSBSim actuator plugin
+ *
+ * @author Jaeyoung Lim <jaeyoung@auterion.com>
+ */
+
+#include "configuration_parser.h"
+
+bool ConfigurationParser::ParseEnvironmentVariables() {
+  if (const char* headless_char = std::getenv("HEADLESS")) {
+    _headless = !std::strcmp(headless_char, "1");
+  }
+  return true;
+}
+
+bool ConfigurationParser::ParseArgV(int argc, char* const argv[]) {
+  // TODO: Parse HITL Variables
+  if (argc < 5) {
+    std::cout << "This is a JSBSim integration for PX4 SITL/HITL simulations" << std::endl;
+    std::cout << "   Usage: " << argv[0] << "<aircraft_path> <aircraft> <config> <scene> <headless>" << std::endl;
+    std::cout << "       <aircraft_path>: Aircraft directory path which the <aircraft> definition is located e.g. "
+                 "`models/Rascal`"
+              << std::endl;
+    std::cout << "       <aircraft>: Aircraft file to use inside the <aircraft_path> e.g. Rascal110-JSBSim"
+              << std::endl;
+    std::cout << "       <config>: Simulation config file name under the `configs` directory e.g. rascal" << std::endl;
+    std::cout << "       <scene>: Location / scene where the vehicle should be spawned in e.g. LSZH" << std::endl;
+    return false;
+  }
+
+  // TODO: Switch to getopt
+  _init_script_path = std::string(argv[4]);
+
+  return true;
+}
+
+bool ConfigurationParser::ParseConfigFile(const std::string& path) {
+  _doc = TiXmlDocument(path);
+  if (!_doc.LoadFile()) {
+    std::cerr << "[ConfigurationParser] Could not load actuator configs from configuration file: " << path << std::endl;
+    return false;
+  }
+  _config = std::make_shared<TiXmlHandle>(_doc.RootElement());
+
+  TiXmlElement* model_config = _config->Element();
+  if (model_config) {
+    _model_name = model_config->Attribute("name");
+  } else {
+    std::cerr << "[ConfigurationParser] Incorrect or invalid model name" << std::endl;
+    return false;
+  }
+
+  return true;
+}
+

--- a/src/sensor_airspeed_plugin.cpp
+++ b/src/sensor_airspeed_plugin.cpp
@@ -41,10 +41,13 @@
 
 #include "sensor_airspeed_plugin.h"
 
-SensorAirspeedPlugin::SensorAirspeedPlugin(JSBSim::FGFDMExec *jsbsim)
-    : SensorPlugin(jsbsim) {}
+SensorAirspeedPlugin::SensorAirspeedPlugin(JSBSim::FGFDMExec* jsbsim) : SensorPlugin(jsbsim) {}
 
 SensorAirspeedPlugin::~SensorAirspeedPlugin() {}
+
+void SensorAirspeedPlugin::setSensorConfigs(const TiXmlElement& configs) {
+  GetConfigElement<double>(configs, "diff_pressure_stddev", _diff_pressure_stddev);
+}
 
 SensorData::Airspeed SensorAirspeedPlugin::getData() {
   double sim_time = _sim_ptr->GetSimTime();
@@ -55,7 +58,7 @@ SensorData::Airspeed SensorAirspeedPlugin::getData() {
   const double density_ratio = powf((temperature_msl / temperature_local), 4.256f);
   float rho = 1.225f / density_ratio;
 
-  const double diff_pressure_noise = standard_normal_distribution_(_random_generator) * diff_pressure_stddev_;
+  const double diff_pressure_noise = standard_normal_distribution_(_random_generator) * _diff_pressure_stddev;
 
   double vel_a = getAirspeed();
 

--- a/src/sensor_baro_plugin.cpp
+++ b/src/sensor_baro_plugin.cpp
@@ -41,12 +41,16 @@
 
 #include "sensor_baro_plugin.h"
 
-SensorBaroPlugin::SensorBaroPlugin(JSBSim::FGFDMExec *jsbsim)
-    : SensorPlugin(jsbsim) {
+SensorBaroPlugin::SensorBaroPlugin(JSBSim::FGFDMExec* jsbsim) : SensorPlugin(jsbsim) {
   _standard_normal_distribution = std::normal_distribution<double>(0.0, 1.0);
 }
 
 SensorBaroPlugin::~SensorBaroPlugin() {}
+
+void SensorBaroPlugin::setSensorConfigs(const TiXmlElement& configs) {
+  GetConfigElement<double>(configs, "drift_pa", _baro_drift_pa);
+  GetConfigElement<double>(configs, "rnd_y2", _baro_rnd_y2);
+}
 
 SensorData::Barometer SensorBaroPlugin::getData() {
   double sim_time = _sim_ptr->GetSimTime();

--- a/src/sensor_gps_plugin.cpp
+++ b/src/sensor_gps_plugin.cpp
@@ -41,9 +41,11 @@
 
 #include "sensor_gps_plugin.h"
 
-SensorGpsPlugin::SensorGpsPlugin(JSBSim::FGFDMExec *jsbsim) : SensorPlugin(jsbsim) { _update_rate = 1.0; }
+SensorGpsPlugin::SensorGpsPlugin(JSBSim::FGFDMExec* jsbsim) : SensorPlugin(jsbsim) { _update_rate = 1.0; }
 
 SensorGpsPlugin::~SensorGpsPlugin() {}
+
+void SensorGpsPlugin::setSensorConfigs(const TiXmlElement& configs) {}
 
 SensorData::Gps SensorGpsPlugin::getData() {
   double sim_time = _sim_ptr->GetSimTime();

--- a/src/sensor_imu_plugin.cpp
+++ b/src/sensor_imu_plugin.cpp
@@ -41,9 +41,7 @@
 
 #include "sensor_imu_plugin.h"
 
-
-SensorImuPlugin::SensorImuPlugin(JSBSim::FGFDMExec* jsbsim)
-    : SensorPlugin(jsbsim) {
+SensorImuPlugin::SensorImuPlugin(JSBSim::FGFDMExec* jsbsim) : SensorPlugin(jsbsim) {
   _standard_normal_distribution = std::normal_distribution<double>(0.0, 1.0);
 
   double sigma_bon_g = gyroscope_turn_on_bias_sigma;
@@ -55,6 +53,17 @@ SensorImuPlugin::SensorImuPlugin(JSBSim::FGFDMExec* jsbsim)
 }
 
 SensorImuPlugin::~SensorImuPlugin() {}
+
+void SensorImuPlugin::setSensorConfigs(const TiXmlElement& configs) {
+  GetConfigElement<double>(configs, "gyroscope_noise_density", gyroscope_noise_density);
+  GetConfigElement<double>(configs, "gyroscope_random_walk", gyroscope_random_walk);
+  GetConfigElement<double>(configs, "gyroscope_bias_correlation_time", gyroscope_bias_correlation_time);
+  GetConfigElement<double>(configs, "gyroscope_turn_on_bias_sigma", gyroscope_turn_on_bias_sigma);
+  GetConfigElement<double>(configs, "accelerometer_noise_density", accelerometer_noise_density);
+  GetConfigElement<double>(configs, "accelerometer_random_walk", accelerometer_random_walk);
+  GetConfigElement<double>(configs, "accelerometer_bias_correlation_time", accelerometer_bias_correlation_time);
+  GetConfigElement<double>(configs, "accelerometer_turn_on_bias_sigma", accelerometer_turn_on_bias_sigma);
+}
 
 SensorData::Imu SensorImuPlugin::getData() {
   double sim_time = _sim_ptr->GetSimTime();

--- a/src/sensor_mag_plugin.cpp
+++ b/src/sensor_mag_plugin.cpp
@@ -41,12 +41,17 @@
 
 #include "sensor_mag_plugin.h"
 
-SensorMagPlugin::SensorMagPlugin(JSBSim::FGFDMExec* jsbsim)
-    : SensorPlugin(jsbsim) {
+SensorMagPlugin::SensorMagPlugin(JSBSim::FGFDMExec* jsbsim) : SensorPlugin(jsbsim) {
   _standard_normal_distribution = std::normal_distribution<double>(0.0, 1.0);
 }
 
 SensorMagPlugin::~SensorMagPlugin() {}
+
+void SensorMagPlugin::setSensorConfigs(const TiXmlElement& configs) {
+  GetConfigElement<double>(configs, "noise_density", _noise_density);
+  GetConfigElement<double>(configs, "random_walk", _random_walk);
+  GetConfigElement<double>(configs, "bias_correlation_time", _bias_correlation_time);
+}
 
 SensorData::Magnetometer SensorMagPlugin::getData() {
   double sim_time = _sim_ptr->GetSimTime();


### PR DESCRIPTION
**Problem Description**
There needs a way to be able to configure the jsbsim in various ways.
- Configure the JSBSim FDM models
- Configure sensor configurations on the vehicle

**Solution**
This adds a configuration parser that configures the jsbsim bridge with three systems. The lower elements on the list have higher priorities.
- Configuration files: There exists one configuration file for each models. The configuration file exists under the `config` directory.
- Command line arguments: Command line arguments are passed to configure the bridge dynamically on execution.
- Environment variables: Use environment variables to override some configurations.

This also improves what are passed as command line arguments. The improvements are as the following. 
- The command line arguments that are necessary is reduced to 1. Although it sitll uses the 3rd argument, once this PR is merged I will switch to `getopt` based command line interface, since this also requires changes in the `sitl_run.sh` script in PX4/Firmware
- The model directory/model file that was being handled in https://github.com/PX4/Firmware/blob/master/Tools/setup_jsbsim.bash is no longer necessary. Instead, it is specified as part of the config file. If the `jsbsimbridge` tag is not specified, it defaults to the `models/<model>/<model>.xml` path as this is the default behavior of JSBSim
```
    <jsbsimbridge>
        <aircraft_directory>models/Rascal</aircraft_directory>
        <aircraft_model>Rascal110-JSBSim</aircraft_model>
    </jsbsimbridge>
```

**Additional Context**

- This change is needed to make the scenario loading more convenient from https://github.com/PX4/px4-jsbsim-bridge/pull/7
- Multiple vehicle scenarios are not incorporated in the design yet. 