### PR TITLE
Set cmake flags for clean build logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,10 @@ else()
 endif()
 
 add_definitions(-DJSBSIM_ROOT_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+add_definitions(
+    -Wno-address-of-packed-member   # MAVLink annoyances
+    -Wno-deprecated-declarations # MAVLink annoyances
+)
 
 include_directories(include)
 


### PR DESCRIPTION
**Problem Description**
warnings from mavlink would flood the build log making it hard to identify actual issues / warnings during the build

**Solution**
This commit suppresses the warnings that were caused from mavlink 