### PR TITLE
Use getopts for parsing commandline arguments

### DIFF
--- a/include/configuration_parser.h
+++ b/include/configuration_parser.h
@@ -46,17 +46,23 @@
 #include <tinyxml.h>
 #include <Eigen/Eigen>
 
+enum ArgResult {
+  ARG_SUCCESS, ARG_HELP, ARG_ERROR
+};
+
 class ConfigurationParser {
  public:
+
   ConfigurationParser() = default;
   ~ConfigurationParser() = default;
   bool ParseEnvironmentVariables();
   bool ParseConfigFile(const std::string& path);
-  bool ParseArgV(int argc, char* const argv[]);
+  ArgResult ParseArgV(int argc, char* const argv[]);
   inline bool isHeadless() { return _headless; }
   inline std::shared_ptr<TiXmlHandle> XmlHandle() { return _config; }
   inline std::string getInitScriptPath() { return _init_script_path; }
   inline std::string getModelName() { return _model_name; }
+  static void GenerateHelpMessage(char *argv[]);
 
  private:
   TiXmlDocument _doc;

--- a/include/configuration_parser.h
+++ b/include/configuration_parser.h
@@ -46,8 +46,8 @@
 #include <tinyxml.h>
 #include <Eigen/Eigen>
 
-enum ArgResult {
-  ARG_SUCCESS, ARG_HELP, ARG_ERROR
+enum class ArgResult {
+  Success, Help, Error
 };
 
 class ConfigurationParser {
@@ -62,7 +62,7 @@ class ConfigurationParser {
   inline std::shared_ptr<TiXmlHandle> XmlHandle() { return _config; }
   inline std::string getInitScriptPath() { return _init_script_path; }
   inline std::string getModelName() { return _model_name; }
-  static void GenerateHelpMessage(char *argv[]);
+  static void PrintHelpMessage(char *argv[]);
 
  private:
   TiXmlDocument _doc;

--- a/src/configuration_parser.cpp
+++ b/src/configuration_parser.cpp
@@ -51,12 +51,7 @@ bool ConfigurationParser::ParseArgV(int argc, char* const argv[]) {
   // TODO: Parse HITL Variables
   if (argc < 5) {
     std::cout << "This is a JSBSim integration for PX4 SITL/HITL simulations" << std::endl;
-    std::cout << "   Usage: " << argv[0] << "<aircraft_path> <aircraft> <config> <scene> <headless>" << std::endl;
-    std::cout << "       <aircraft_path>: Aircraft directory path which the <aircraft> definition is located e.g. "
-                 "`models/Rascal`"
-              << std::endl;
-    std::cout << "       <aircraft>: Aircraft file to use inside the <aircraft_path> e.g. Rascal110-JSBSim"
-              << std::endl;
+    std::cout << "   Usage: " << argv[0] << "<config> <scene>" << std::endl;
     std::cout << "       <config>: Simulation config file name under the `configs` directory e.g. rascal" << std::endl;
     std::cout << "       <scene>: Location / scene where the vehicle should be spawned in e.g. LSZH" << std::endl;
     return false;

--- a/src/configuration_parser.cpp
+++ b/src/configuration_parser.cpp
@@ -52,33 +52,28 @@ bool ConfigurationParser::ParseEnvironmentVariables() {
 ArgResult ConfigurationParser::ParseArgV(int argc, char* const argv[]) {
     static const struct option options[] = {
         {"scene", required_argument, nullptr, 's'},
-        {"device", required_argument, nullptr, 'd'},
     };
 
     int c;
-    while ((c = getopt_long(argc, argv, ":s:h", options, nullptr)) >= 0) {
+    while ((c = getopt_long(argc, argv, "s:h", options, nullptr)) >= 0) {
         switch (c) {
             case 'h': {
-              return ARG_HELP;
+              return ArgResult::Help;
               break;
             }
             case 's': {
               _init_script_path = std::string(optarg);
               break;
             }
-            case ':': {
-                // Do nothing if an empty variable has been passed for all options
-                break;
-            }
             case '?':
             default: {
               std::cout << "Unknown Options" << std::endl;
-              return ARG_ERROR;
+              return ArgResult::Error;
             }
         }
     }
 
-  return ARG_SUCCESS;
+  return ArgResult::Success;
 }
 
 bool ConfigurationParser::ParseConfigFile(const std::string& path) {
@@ -100,7 +95,7 @@ bool ConfigurationParser::ParseConfigFile(const std::string& path) {
   return true;
 }
 
-void ConfigurationParser::GenerateHelpMessage(char *argv[]) {
+void ConfigurationParser::PrintHelpMessage(char *argv[]) {
   std::cout << argv[0] << " aircraft [options]\n\n"
     << "  aircraft      Aircraft config file name e.g. rascal"
     << "  -h | --help   Print available options\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,10 +47,23 @@ int main(int argc, char *argv[]) {
   ConfigurationParser config;
   if (argc > 1) {
     // Path to config file
-    std::string path = std::string(JSBSIM_ROOT_DIR) + "/configs/" + std::string(argv[3]) + ".xml";
+    std::string path = std::string(JSBSIM_ROOT_DIR) + "/configs/" + std::string(argv[1]) + ".xml";
     config.ParseConfigFile(path);
   }
-  config.ParseArgV(argc, argv);
+  switch (config.ParseArgV(argc, argv)) {
+    case ARG_SUCCESS : {
+      break;
+    }
+    case ARG_HELP : {
+      ConfigurationParser::GenerateHelpMessage(argv);
+      return 0;
+    }
+    default:
+    case ARG_ERROR: {
+      ConfigurationParser::GenerateHelpMessage(argv);
+      return 1;
+    }
+  }
   config.ParseEnvironmentVariables();
 
   // Configure JSBSim

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,14 +42,16 @@
 #include "jsbsim_bridge.h"
 
 int main(int argc, char *argv[]) {
-  // Path to config file
-  std::string path = std::string(JSBSIM_ROOT_DIR) + "/configs/" + std::string(argv[3]) + ".xml";
 
   // Parse Configurations
   ConfigurationParser config;
-  config.ParseEnvironmentVariables();
+  if (argc > 1) {
+    // Path to config file
+    std::string path = std::string(JSBSIM_ROOT_DIR) + "/configs/" + std::string(argv[3]) + ".xml";
+    config.ParseConfigFile(path);
+  }
   config.ParseArgV(argc, argv);
-  config.ParseConfigFile(path);
+  config.ParseEnvironmentVariables();
 
   // Configure JSBSim
   JSBSim::FGFDMExec *fdmexec = new JSBSim::FGFDMExec();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,16 +51,16 @@ int main(int argc, char *argv[]) {
     config.ParseConfigFile(path);
   }
   switch (config.ParseArgV(argc, argv)) {
-    case ARG_SUCCESS : {
+    case ArgResult::Success : {
       break;
     }
-    case ARG_HELP : {
-      ConfigurationParser::GenerateHelpMessage(argv);
+    case ArgResult::Help : {
+      ConfigurationParser::PrintHelpMessage(argv);
       return 0;
     }
     default:
-    case ARG_ERROR: {
-      ConfigurationParser::GenerateHelpMessage(argv);
+    case ArgResult::Error : {
+      ConfigurationParser::PrintHelpMessage(argv);
       return 1;
     }
   }


### PR DESCRIPTION
**Problem Description**
This PR switches the command line argument to getopts, so that it can better handle required/optional variables. This also solves the problem that more than 5 arguments had to be passed to run the bridge. Now only the config file needs to be passed, with the scene with the `-s` flag

*Before PR*
```
jsbsim_bridge" "models/${JSBSIM_AIRCRAFT_DIR}" $JSBSIM_AIRCRAFT_MODEL ${model} "${src_path}/Tools/jsbsim_bridge/scene/${world}.xml" $HEADLESS
```

*After PR*
```
jsbsim_bridge" ${model} -s "${src_path}/Tools/jsbsim_bridge/scene/${world}.xml"
```


**Next steps**
- Support HITL options by passing HITL related arguments