### PR TITLE
Add ROS support for JSBSim Bridge

### DIFF
--- a/.github/workflows/catkin_build_test.yml
+++ b/.github/workflows/catkin_build_test.yml
@@ -1,0 +1,38 @@
+
+name: Catkin Build Test
+on:
+  push:
+    branches:
+    - 'master'
+  pull_request:
+    branches:
+    - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {rosdistro: 'melodic', container: 'px4io/px4-dev-ros-melodic:2020-11-02'}
+          - {rosdistro: 'noetic', container: 'px4io/px4-dev-ros-noetic:2020-11-02'}
+    container: ${{ matrix.config.container }}
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        token: ${{ secrets.ACCESS_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: release_build_test
+      working-directory: 
+      run: |
+        mkdir -p $HOME/catkin_ws/src;
+        cd $HOME/catkin_ws
+        catkin init
+        catkin config --extend "/opt/ros/${{matrix.config.rosdistro}}"
+        catkin config --merge-devel
+        cd $HOME/catkin_ws/src
+        ln -s $GITHUB_WORKSPACE
+        cd $HOME/catkin_ws
+        catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -DCATKIN_ENABLE_TESTING=False
+        catkin build -j$(nproc) -l$(nproc) jsbsim_bridge

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,3 +83,53 @@ target_include_directories(jsbsim_bridge
 				PUBLIC ${MAVLINK_INCLUDE_DIRS} ${JSBSIM_INCLUDE_DIR} ${Boost_INCLUDE_DIR} ${EIGEN3_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS})
 
 target_link_libraries(jsbsim_bridge ${JSBSIM_LIBRARY} ${Boost_SYSTEM_LIBRARY_RELEASE} ${Boost_THREAD_LIBRARY_RELEASE} ${Boost_TIMER_LIBRARY_RELEASE} ${EIGEN_LIBRARIES} ${TinyXML_LIBRARIES})
+
+# see if catkin was invoked to build this
+if (CATKIN_DEVEL_PREFIX)
+	message(STATUS "catkin ENABLED")
+	find_package(catkin REQUIRED)
+	if (catkin_FOUND)
+		catkin_package()
+	else()
+		message(FATAL_ERROR "catkin not found")
+	endif()
+
+	find_package(catkin REQUIRED COMPONENTS
+			roscpp
+			rospy
+			mavlink
+		)
+
+	catkin_package(
+		INCLUDE_DIRS include
+		LIBRARIES geometric_controller
+		CATKIN_DEPENDS roscpp rospy std_msgs
+	)
+
+  add_executable(jsbsim_bridge_node
+	src/jsbsim_bridge_node.cpp
+	src/jsbsim_bridge_ros.cpp
+	src/configuration_parser.cpp
+	src/jsbsim_bridge.cpp
+	src/geo_mag_declination.cpp
+	src/mavlink_interface.cpp
+	src/actuator_plugin.cpp
+	src/sensor_plugin.cpp
+	src/sensor_airspeed_plugin.cpp
+	src/sensor_baro_plugin.cpp
+	src/sensor_imu_plugin.cpp
+	src/sensor_gps_plugin.cpp
+	src/sensor_mag_plugin.cpp
+	)
+
+  target_include_directories(jsbsim_bridge_node
+    BEFORE
+	PUBLIC ${catkin_INCLUDE_DIRS} ${MAVLINK_INCLUDE_DIRS} ${JSBSIM_INCLUDE_DIR} ${Boost_INCLUDE_DIR} ${EIGEN3_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS}
+	)
+
+	target_link_libraries(jsbsim_bridge_node ${catkin_LIBRARIES} ${JSBSIM_LIBRARY} ${Boost_SYSTEM_LIBRARY_RELEASE} ${Boost_THREAD_LIBRARY_RELEASE} ${Boost_TIMER_LIBRARY_RELEASE} ${EIGEN_LIBRARIES} ${TinyXML_LIBRARIES}
+	)
+
+  else()
+  message(STATUS "catkin DISABLED")
+endif()

--- a/include/jsbsim_bridge_ros.h
+++ b/include/jsbsim_bridge_ros.h
@@ -1,3 +1,4 @@
+
 /****************************************************************************
  *
  *   Copyright (c) 2020 Auterion AG. All rights reserved.
@@ -30,49 +31,50 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  ****************************************************************************/
+
 /**
- * @brief JSBSim Bridge Configuration Parser
- *
- * This is a class for the JSBSim actuator plugin
  *
  * @author Jaeyoung Lim <jaeyoung@auterion.com>
+ *
  */
 
-#pragma once
+#ifndef JSBSIM_BRIDGE_ROS_H
+#define JSBSIM_BRIDGE_ROS_H
 
-#include "common.h"
+#include "jsbsim_bridge.h"
 
-#include <memory>
-#include <tinyxml.h>
-#include <Eigen/Eigen>
+#include <ros/ros.h>
 
-enum class ArgResult {
-  Success, Help, Error
+#include <stdio.h>
+#include <cstdlib>
+#include <string>
+#include <sstream>
+
+#include <Eigen/Dense>
+
+using namespace std;
+using namespace Eigen;
+
+class JSBSimBridgeRos
+{
+  public:
+    JSBSimBridgeRos(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
+    virtual ~JSBSimBridgeRos();
+
+  private:
+    void simloopCallback(const ros::TimerEvent& event);
+    void statusloopCallback(const ros::TimerEvent& event);
+
+    ros::NodeHandle nh_;
+    ros::NodeHandle nh_private_;
+    ros::Timer simloop_timer_, statusloop_timer_;
+
+    JSBSim::FGFDMExec* fdmexec_;
+    ConfigurationParser config_;
+    std::unique_ptr<JSBSimBridge> jsbsim_bridge_;
+
+    std::string path;
+    std::string script_path;
+
 };
-
-class ConfigurationParser {
- public:
-
-  ConfigurationParser() = default;
-  ~ConfigurationParser() = default;
-  bool ParseEnvironmentVariables();
-  bool ParseConfigFile(const std::string& path);
-  ArgResult ParseArgV(int argc, char* const argv[]);
-  bool isHeadless() { return _headless; }
-  std::shared_ptr<TiXmlHandle> XmlHandle() { return _config; }
-  std::string getInitScriptPath() { return _init_script_path; }
-  std::string getModelName() { return _model_name; }
-  int getRealtimeFactor() { return _realtime_factor; }  
-  void setHeadless(bool headless) { _headless = headless; }
-  void setInitScriptPath(std::string path) { _init_script_path = path; }
-  static void PrintHelpMessage(char *argv[]);
-
- private:
-  TiXmlDocument _doc;
-  std::shared_ptr<TiXmlHandle> _config;
-
-  bool _headless{false};
-  std::string _init_script_path;
-  std::string _model_name;
-  float _realtime_factor{1.0};
-};
+#endif

--- a/launch/px4_jsbsim_bridge.launch
+++ b/launch/px4_jsbsim_bridge.launch
@@ -1,0 +1,41 @@
+<launch>
+  <arg name="est" default="ekf2"/>
+  <arg name="vehicle" default="rascal"/>
+  <arg name="fcu_url" default="udp://:14540@127.0.0.1:14557"/>
+  <arg name="gcs_url" default="" />
+  <arg name="tgt_system" default="1" />
+  <arg name="tgt_component" default="1" />
+  <arg name="command_input" default="2" />
+  <arg name="gazebo_simulation" default="true" />
+  <arg name="visualization" default="true"/>
+  <arg name="log_output" default="screen" />
+  <arg name="fcu_protocol" default="v2.0" />
+  <arg name="respawn_mavros" default="false" />
+  <env name="PX4_SIM_MODEL" value="$(arg vehicle)" />
+  <env name="PX4_ESTIMATOR" value="$(arg est)" />
+
+  <include file="$(find mavros)/launch/node.launch">
+      <arg name="pluginlists_yaml" value="$(find mavros)/launch/px4_pluginlists.yaml" />
+      <arg name="config_yaml" value="$(find mavros)/launch/px4_config.yaml" />
+
+      <arg name="fcu_url" value="$(arg fcu_url)" />
+      <arg name="gcs_url" value="$(arg gcs_url)" />
+      <arg name="tgt_system" value="$(arg tgt_system)" />
+      <arg name="tgt_component" value="$(arg tgt_component)" />
+      <arg name="log_output" value="$(arg log_output)" />
+      <arg name="fcu_protocol" value="$(arg fcu_protocol)" />
+      <arg name="respawn_mavros" default="$(arg respawn_mavros)" />
+  </include>
+
+  <!-- PX4 configs -->
+  <arg name="interactive" default="true"/>
+  <!-- PX4 SITL -->
+  <arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+  <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
+  <node name="sitl" pkg="px4" type="px4" output="screen"
+      args="$(find px4)/build/px4_sitl_default/etc -s etc/init.d-posix/rcS $(arg px4_command_arg1)" required="true"/>
+
+  <node pkg="jsbsim_bridge" type="jsbsim_bridge_node" name="jsbsim_bridge" output="screen">
+  </node>
+
+</launch>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,30 @@
+<package>
+  <name>jsbsim_bridge</name>
+  <version>0.0.1</version>
+  <description>Ros interface for px4-jsbsim-bridge</description>
+
+  <maintainer email="jaeyoung@auterion.com">Jaeyoung Lim</maintainer>
+
+  <author>Jaeyoung Lim</author>
+
+  <license>BSD-3</license>
+
+  <url type="website">https://github.com/Auterion/px4-jsbsim-bridge.git</url>
+  <url type="bugtracker">https://github.com/Auterion/px4-jsbsim-bridge.git</url>
+
+  <!-- Dependencies which this package needs to build itself. -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>mavlink</build_depend>
+
+  <!-- Dependencies needed after this package is compiled. -->
+  <run_depend>roscpp</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>mavros</run_depend>
+
+  <export>
+  </export>
+</package>

--- a/src/jsbsim_bridge_node.cpp
+++ b/src/jsbsim_bridge_node.cpp
@@ -1,3 +1,4 @@
+
 /****************************************************************************
  *
  *   Copyright (c) 2020 Auterion AG. All rights reserved.
@@ -30,49 +31,25 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  ****************************************************************************/
+
 /**
- * @brief JSBSim Bridge Configuration Parser
- *
- * This is a class for the JSBSim actuator plugin
+ * @file main.cpp
  *
  * @author Jaeyoung Lim <jaeyoung@auterion.com>
+ *
  */
 
-#pragma once
+#include "jsbsim_bridge_ros.h"
 
-#include "common.h"
 
-#include <memory>
-#include <tinyxml.h>
-#include <Eigen/Eigen>
+int main(int argc, char** argv) {
+  ros::init(argc, argv, "jsbsim_bridge");
+  ros::NodeHandle nh("");
+  ros::NodeHandle nh_private("~");
 
-enum class ArgResult {
-  Success, Help, Error
-};
+  // // Configure JSBSim
+  JSBSimBridgeRos* jsbsim_bridge_ros = new JSBSimBridgeRos(nh, nh_private);
 
-class ConfigurationParser {
- public:
-
-  ConfigurationParser() = default;
-  ~ConfigurationParser() = default;
-  bool ParseEnvironmentVariables();
-  bool ParseConfigFile(const std::string& path);
-  ArgResult ParseArgV(int argc, char* const argv[]);
-  bool isHeadless() { return _headless; }
-  std::shared_ptr<TiXmlHandle> XmlHandle() { return _config; }
-  std::string getInitScriptPath() { return _init_script_path; }
-  std::string getModelName() { return _model_name; }
-  int getRealtimeFactor() { return _realtime_factor; }  
-  void setHeadless(bool headless) { _headless = headless; }
-  void setInitScriptPath(std::string path) { _init_script_path = path; }
-  static void PrintHelpMessage(char *argv[]);
-
- private:
-  TiXmlDocument _doc;
-  std::shared_ptr<TiXmlHandle> _config;
-
-  bool _headless{false};
-  std::string _init_script_path;
-  std::string _model_name;
-  float _realtime_factor{1.0};
-};
+  ros::spin();
+  return 0;
+}


### PR DESCRIPTION
**Problem Description**
Previously, when using PX4 in the ROS environment, the only way to simulate PX4 was through Gazebo. However, since Gazebo has limited dynamics modeled in the simulation, it was hard for users to evaluate flight control related applications in Gazebo.

Supporting JSBSim will enable developers using ROS to be able to evaluate their software with more accurate flight dynamics.

**Solution**
This PR adds ROS support for the JSBSim bridge. This enables users using ROS/MAVROS to be able to run JSBSim as a SITL simulation environment. A ros node `jsbsimbridge_ros` is responsible for initializing and running the simulation. 

The configurations can be done through the launchfile
```
          <param name="config" value="config/rascal.xml" />
          <param name="script" value="scene/LSZH.xml" />
          <param name="dt" value="0.004" />
```

A launchfile is is added to automate running mavros / jsbsim togethe. The ROS node can be run through
```
roslaunch jsbsim_bridge px4_jsbsim_bridge.launch
```
The launchfile runs PX4 SITL, MAVROS  and a jsbsim_bridge to expose jsbsim to PX4 SITL, and mavros to expose PX4 mavlink messages to ROS.

**Additional Context**
- Added jsbsim to the ROS container in https://github.com/PX4/containers/pull/279