### PR TITLE
Add support for flying wing vehicle (malolo)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "models/Rascal"]
 	path = models/Rascal
 	url = https://github.com/ThunderFly-aerospace/FlightGear-Rascal.git
+[submodule "models/ATI-Resolution"]
+	path = models/ATI-Resolution
+	url = https://github.com/FGMEMBERS/ATI-Resolution.git

--- a/configs/malolo.xml
+++ b/configs/malolo.xml
@@ -1,0 +1,43 @@
+<model name="rascal">
+    <jsbsimbridge>
+        <aircraft_directory>models/ATI-Resolution</aircraft_directory>
+        <aircraft_model>Malolo1</aircraft_model>
+    </jsbsimbridge>
+    <mavlink_interface>
+        <tcp_port>4560</tcp_port>
+    </mavlink_interface>
+    <sensors>
+        <imu>
+        </imu>
+        <gps>
+        </gps>
+        <barometer>
+        </barometer>
+        <magnetometer>
+        </magnetometer>
+        <airspeed>
+        </airspeed>
+    </sensors>
+    <actuators>
+        <channel name="rudder">
+            <index>2</index>
+            <scale>-1</scale>
+            <property>fcs/rudder-cmd-norm</property>
+        </channel>
+        <channel name="aileron">
+            <index>5</index>
+            <scale>-1</scale>
+            <property>fcs/aileron-cmd-norm</property>
+        </channel>
+        <channel name="elevator">
+            <index>7</index>
+            <scale>-1</scale>
+            <property>fcs/elevator-cmd-norm</property>
+        </channel>
+        <channel name="throttle">
+            <index>4</index>
+            <scale>1</scale>
+            <property>fcs/throttle-cmd-norm</property>
+        </channel>
+    </actuators>
+</model>


### PR DESCRIPTION
**Problem Description**
This adds support to a flying wing vehicle called [Malolo1](http://wiki.flightgear.org/Malolo_1) to be used in JSBSim and PX4 SITL. @mvacanti @RomanBapst FYI

Since the vehicle is distributed as LGPL-v2 license, the vehicle is added as a submodule to the repository. The vehicle model is distributed through https://github.com/FGMEMBERS/ATI-Resolution

- Unfortunately, `ATI-Resolution` name is encoded in the namepsace of the scripts, so re-naming this file will likely break the model, therefore the name was kept.
- The vehicle is controlled via a flight control system therefore px4 just needs to pass the axis inputs (elevator / aileron .etc) directly to the vehicle. 

**Test**
The vehicle can be flown in PX4 SITL with the following make command
```
make px4_sitl jsbsim_malolo
```

Below shows a screenshot of the vehicle being visualized in flightgear

![image](https://user-images.githubusercontent.com/5248102/96002883-ec945180-0e39-11eb-8a83-20bae4fac671.png)

**Additional Context**
