### PR TITLE
Enable user defined IMU Parameters from JSBSim

### DIFF
--- a/configs/quadrotor_x.xml
+++ b/configs/quadrotor_x.xml
@@ -4,6 +4,12 @@
     </mavlink_interface>
     <sensors>
         <imu>
+            <jsb_acc_x>px4/acc-x</jsb_acc_x>
+            <jsb_acc_y>px4/acc-y</jsb_acc_y>
+            <jsb_acc_z>px4/acc-z</jsb_acc_z>
+            <jsb_gyro_x>px4/gyro-x</jsb_gyro_x>
+            <jsb_gyro_y>px4/gyro-y</jsb_gyro_y>
+            <jsb_gyro_z>px4/gyro-z</jsb_gyro_z>
         </imu>
         <gps>
         </gps>

--- a/include/sensor_imu_plugin.h
+++ b/include/sensor_imu_plugin.h
@@ -100,12 +100,12 @@ class SensorImuPlugin : public SensorPlugin {
   * ensure you have set the eyepoint location as to where you expect accelerometer measurements
   * or more appropriately, use the px4_default_imu_sensor.xml configuration.
   */
-  std::string jsb_acc_x = "accelerations/a-pilot-x-ft_sec2";
-  std::string jsb_acc_y = "accelerations/a-pilot-y-ft_sec2";
-  std::string jsb_acc_z = "accelerations/a-pilot-z-ft_sec2";
+  std::string _jsb_acc_x = "accelerations/a-pilot-x-ft_sec2";
+  std::string _jsb_acc_y = "accelerations/a-pilot-y-ft_sec2";
+  std::string _jsb_acc_z = "accelerations/a-pilot-z-ft_sec2";
 
   // PX4 requires axis angular acceleration vs. body frame acceleration.
-  std::string jsb_gyro_x = "velocities/p-rad_sec";
-  std::string jsb_gyro_y = "velocities/q-rad_sec";
-  std::string jsb_gyro_z = "velocities/r-rad_sec";
+  std::string _jsb_gyro_x = "velocities/p-rad_sec";
+  std::string _jsb_gyro_y = "velocities/q-rad_sec";
+  std::string _jsb_gyro_z = "velocities/r-rad_sec";
 };

--- a/include/sensor_imu_plugin.h
+++ b/include/sensor_imu_plugin.h
@@ -95,4 +95,17 @@ class SensorImuPlugin : public SensorPlugin {
   Eigen::Vector3d _accelerometer_turn_on_bias{Eigen::Vector3d::Zero()};
 
   std::normal_distribution<double> _standard_normal_distribution;
+
+  /** Accelerations are affected by JSBSim airframe configuration <location name="EYEPOINT">
+  * ensure you have set the eyepoint location as to where you expect accelerometer measurements
+  * or more appropriately, use the px4_default_imu_sensor.xml configuration.
+  */
+  std::string jsb_acc_x = "accelerations/a-pilot-x-ft_sec2";
+  std::string jsb_acc_y = "accelerations/a-pilot-y-ft_sec2";
+  std::string jsb_acc_z = "accelerations/a-pilot-z-ft_sec2";
+
+  // PX4 requires axis angular acceleration vs. body frame acceleration.
+  std::string jsb_gyro_x = "velocities/p-rad_sec";
+  std::string jsb_gyro_y = "velocities/q-rad_sec";
+  std::string jsb_gyro_z = "velocities/r-rad_sec";
 };

--- a/models/quadrotor_x/quadrotor_x.xml
+++ b/models/quadrotor_x/quadrotor_x.xml
@@ -452,4 +452,5 @@
       </function>
     </axis>
   </aerodynamics>
+  <system file="px4_default_imu_sensor"/>
 </fdm_config>

--- a/src/sensor_imu_plugin.cpp
+++ b/src/sensor_imu_plugin.cpp
@@ -63,6 +63,12 @@ void SensorImuPlugin::setSensorConfigs(const TiXmlElement& configs) {
   GetConfigElement<double>(configs, "accelerometer_random_walk", accelerometer_random_walk);
   GetConfigElement<double>(configs, "accelerometer_bias_correlation_time", accelerometer_bias_correlation_time);
   GetConfigElement<double>(configs, "accelerometer_turn_on_bias_sigma", accelerometer_turn_on_bias_sigma);
+  GetConfigElement<std::string>(configs, "jsb_acc_x", jsb_acc_x);
+  GetConfigElement<std::string>(configs, "jsb_acc_y", jsb_acc_y);
+  GetConfigElement<std::string>(configs, "jsb_acc_z", jsb_acc_z);
+  GetConfigElement<std::string>(configs, "jsb_gyro_x", jsb_gyro_x);
+  GetConfigElement<std::string>(configs, "jsb_gyro_y", jsb_gyro_y);
+  GetConfigElement<std::string>(configs, "jsb_gyro_z", jsb_gyro_z);
 }
 
 SensorData::Imu SensorImuPlugin::getData() {
@@ -83,17 +89,17 @@ SensorData::Imu SensorImuPlugin::getData() {
 }
 
 Eigen::Vector3d SensorImuPlugin::getAccelFromJSBSim() {
-  double x = _sim_ptr->GetPropertyValue("accelerations/a-pilot-x-ft_sec2");
-  double y = _sim_ptr->GetPropertyValue("accelerations/a-pilot-y-ft_sec2");
-  double z = _sim_ptr->GetPropertyValue("accelerations/a-pilot-z-ft_sec2");
+  double x = _sim_ptr->GetPropertyValue(jsb_acc_x);
+  double y = _sim_ptr->GetPropertyValue(jsb_acc_y);
+  double z = _sim_ptr->GetPropertyValue(jsb_acc_z);
 
   return Eigen::Vector3d(ftToM(x), ftToM(y), ftToM(z));
 }
 
 Eigen::Vector3d SensorImuPlugin::getGyroFromJSBSim() {
-  double x = _sim_ptr->GetPropertyValue("velocities/p-rad_sec");
-  double y = _sim_ptr->GetPropertyValue("velocities/q-rad_sec");
-  double z = _sim_ptr->GetPropertyValue("velocities/r-rad_sec");
+  double x = _sim_ptr->GetPropertyValue(jsb_gyro_x);
+  double y = _sim_ptr->GetPropertyValue(jsb_gyro_y);
+  double z = _sim_ptr->GetPropertyValue(jsb_gyro_z);
 
   return Eigen::Vector3d(x, y, z);
 }

--- a/src/sensor_imu_plugin.cpp
+++ b/src/sensor_imu_plugin.cpp
@@ -63,12 +63,12 @@ void SensorImuPlugin::setSensorConfigs(const TiXmlElement& configs) {
   GetConfigElement<double>(configs, "accelerometer_random_walk", accelerometer_random_walk);
   GetConfigElement<double>(configs, "accelerometer_bias_correlation_time", accelerometer_bias_correlation_time);
   GetConfigElement<double>(configs, "accelerometer_turn_on_bias_sigma", accelerometer_turn_on_bias_sigma);
-  GetConfigElement<std::string>(configs, "jsb_acc_x", jsb_acc_x);
-  GetConfigElement<std::string>(configs, "jsb_acc_y", jsb_acc_y);
-  GetConfigElement<std::string>(configs, "jsb_acc_z", jsb_acc_z);
-  GetConfigElement<std::string>(configs, "jsb_gyro_x", jsb_gyro_x);
-  GetConfigElement<std::string>(configs, "jsb_gyro_y", jsb_gyro_y);
-  GetConfigElement<std::string>(configs, "jsb_gyro_z", jsb_gyro_z);
+  GetConfigElement<std::string>(configs, "jsb_acc_x", _jsb_acc_x);
+  GetConfigElement<std::string>(configs, "jsb_acc_y", _jsb_acc_y);
+  GetConfigElement<std::string>(configs, "jsb_acc_z", _jsb_acc_z);
+  GetConfigElement<std::string>(configs, "jsb_gyro_x", _jsb_gyro_x);
+  GetConfigElement<std::string>(configs, "jsb_gyro_y", _jsb_gyro_y);
+  GetConfigElement<std::string>(configs, "jsb_gyro_z", _jsb_gyro_z);
 }
 
 SensorData::Imu SensorImuPlugin::getData() {
@@ -89,17 +89,17 @@ SensorData::Imu SensorImuPlugin::getData() {
 }
 
 Eigen::Vector3d SensorImuPlugin::getAccelFromJSBSim() {
-  double x = _sim_ptr->GetPropertyValue(jsb_acc_x);
-  double y = _sim_ptr->GetPropertyValue(jsb_acc_y);
-  double z = _sim_ptr->GetPropertyValue(jsb_acc_z);
+  double x = _sim_ptr->GetPropertyValue(_jsb_acc_x);
+  double y = _sim_ptr->GetPropertyValue(_jsb_acc_y);
+  double z = _sim_ptr->GetPropertyValue(_jsb_acc_z);
 
   return Eigen::Vector3d(ftToM(x), ftToM(y), ftToM(z));
 }
 
 Eigen::Vector3d SensorImuPlugin::getGyroFromJSBSim() {
-  double x = _sim_ptr->GetPropertyValue(jsb_gyro_x);
-  double y = _sim_ptr->GetPropertyValue(jsb_gyro_y);
-  double z = _sim_ptr->GetPropertyValue(jsb_gyro_z);
+  double x = _sim_ptr->GetPropertyValue(_jsb_gyro_x);
+  double y = _sim_ptr->GetPropertyValue(_jsb_gyro_y);
+  double z = _sim_ptr->GetPropertyValue(_jsb_gyro_z);
 
   return Eigen::Vector3d(x, y, z);
 }

--- a/systems/px4_default_imu_sensor.xml
+++ b/systems/px4_default_imu_sensor.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <system name="PX4 IMU Sensor">
 <!--  =================================================================
-This is a generic JSBSim system file to simulate the GPS behavior for PX4.
+This is a generic JSBSim system file to simulate the IMU behavior for PX4.
   =================================================================  -->
 
     <!-- Enable Individual Component Failure -->

--- a/systems/px4_default_imu_sensor.xml
+++ b/systems/px4_default_imu_sensor.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0"?>
+<system name="PX4 IMU Sensor">
+<!--  =================================================================
+This is a generic JSBSim system file to simulate the GPS behavior for PX4.
+  =================================================================  -->
+
+    <!-- Enable Individual Component Failure -->
+    <property value="1">px4/acc_x/on</property>
+    <property value="1">px4/acc_y/on</property>
+    <property value="1">px4/acc_z/on</property>
+
+    <property value="1">px4/gyro_x/on</property>
+    <property value="1">px4/gyro_y/on</property>
+    <property value="1">px4/gyro_z/on</property>
+
+    <channel name="Accelerometer-X" execute="px4/acc_x/on">
+        <accelerometer name="Default-ACC-X">
+            <location unit="M">
+                <x> 0 </x>
+                <y> 0 </y>
+                <z> 0.345 </z>
+            </location>
+            <!--
+            <orientation unit="DEG">
+                <pitch> 0 </pitch>
+                <roll>  0 </roll>
+                <yaw>   0 </yaw>
+            </orientation>
+            <lag> 0 </lag>
+            <noise variation="PERCENT|ABSOLUTE"> number </noise>
+            <quantization name="name">
+                <bits> number </bits>
+                <min> number </min>
+                <max> number </max>
+            </quantization>
+            <drift_rate> number </drift_rate>
+            <gain> number </gain>
+            <bias> number </bias>
+            -->
+            <axis> X </axis>
+            <output> px4/acc-x </output>
+        </accelerometer>
+    </channel>
+
+    <channel name="Accelerometer-Y" execute="px4/acc_y/on">
+        <accelerometer name="Default-ACC-Y">
+            <location unit="M">
+                <x> 0 </x>
+                <y> 0 </y>
+                <z> 0.345 </z>
+            </location>
+            <!--
+            <orientation unit="DEG">
+                <pitch> 0 </pitch>
+                <roll>  0 </roll>
+                <yaw>   0 </yaw>
+            </orientation>
+            <lag> 0 </lag>
+            <noise variation="PERCENT|ABSOLUTE"> number </noise>
+            <quantization name="name">
+                <bits> number </bits>
+                <min> number </min>
+                <max> number </max>
+            </quantization>
+            <drift_rate> number </drift_rate>
+            <gain> number </gain>
+            <bias> number </bias>
+            -->
+            <axis> Y </axis>
+            <output> px4/acc-y </output>
+        </accelerometer>
+    </channel>
+
+    <channel name="Accelerometer-Z" execute="px4/acc_z/on">
+        <accelerometer name="Default-ACC-Z">
+            <location unit="M">
+                <x> 0 </x>
+                <y> 0 </y>
+                <z> 0.345 </z>
+            </location>
+            <!--
+            <orientation unit="DEG">
+                <pitch> 0 </pitch>
+                <roll>  0 </roll>
+                <yaw>   0 </yaw>
+            </orientation>
+            <lag> 0 </lag>
+            <noise variation="PERCENT|ABSOLUTE"> number </noise>
+            <quantization name="name">
+                <bits> number </bits>
+                <min> number </min>
+                <max> number </max>
+            </quantization>
+            <drift_rate> number </drift_rate>
+            <gain> number </gain>
+            <bias> number </bias>
+            -->
+            <axis> Z </axis>
+            <output> px4/acc-z </output>
+        </accelerometer>
+    </channel>
+
+    <channel name="Gyro-X" execute="px4/gyro_x/on">
+        <sensor name="px4/gyro-x">
+            <input>velocities/p-rad_sec</input>
+            <lag> 0 </lag>
+            <!--Adjust as required
+            <noise variation="PERCENT|ABSOLUTE"> number </noise>
+            <quantization name="name">
+                <bits> number </bits>
+                <min> number </min>
+                <max> number </max>
+            </quantization>
+            <drift_rate> number </drift_rate>
+            <gain> number </gain>
+            <bias> number </bias>
+            <delay [type="time|frames"]> number < /delay>
+            -->
+        </sensor>
+    </channel>
+
+    <channel name="Gyro-Y" execute="px4/gyro_y/on">
+        <sensor name="px4/gyro-y">
+            <input>velocities/q-rad_sec</input>
+            <lag> 0 </lag>
+            <!--Adjust as required
+            <noise variation="PERCENT|ABSOLUTE"> number </noise>
+            <quantization name="name">
+                <bits> number </bits>
+                <min> number </min>
+                <max> number </max>
+            </quantization>
+            <drift_rate> number </drift_rate>
+            <gain> number </gain>
+            <bias> number </bias>
+            <delay [type="time|frames"]> number < /delay>
+            -->
+        </sensor>
+    </channel>
+
+    <channel name="Gyro-Z" execute="px4/gyro_z/on">
+        <sensor name="px4/gyro-z">
+            <input>velocities/r-rad_sec</input>
+            <lag> 0 </lag>
+            <!--Adjust as required
+            <noise variation="PERCENT|ABSOLUTE"> number </noise>
+            <quantization name="name">
+                <bits> number </bits>
+                <min> number </min>
+                <max> number </max>
+            </quantization>
+            <drift_rate> number </drift_rate>
+            <gain> number </gain>
+            <bias> number </bias>
+            <delay [type="time|frames"]> number < /delay>
+            -->
+        </sensor>
+    </channel>
+
+</system>
+


### PR DESCRIPTION
@Jaeyoung-Lim this proposal enables the user to map custom JSBSim IMU parameters via the bridge configuration file and JSBSim system definition file. When configuration definition is not provided it will default to the "standard" inputs / behaviors. Additionally this addresses #15 by adding comments to the source and by providing user configurable location and orientation of sensors.