### PR TITLE
Change remote for flightgear rascal

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "models/Rascal"]
 	path = models/Rascal
-	url = https://github.com/ThunderFly-aerospace/FlightGear-Rascal.git
+	url = https://github.com/Auterion/FlightGear-Rascal.git
 [submodule "models/ATI-Resolution"]
 	path = models/ATI-Resolution
 	url = https://github.com/FGMEMBERS/ATI-Resolution.git


### PR DESCRIPTION
This commit switches the flightgear rascal submodule to a different remote, which is a fork of the original repository

Request from @RomanBapst 