### PR TITLE
Enable Hardware-In-The-Loop simulation for JSBSim

### DIFF
--- a/include/configuration_parser.h
+++ b/include/configuration_parser.h
@@ -60,6 +60,9 @@ class ConfigurationParser {
   std::string getInitScriptPath() { return _init_script_path; }
   std::string getModelName() { return _model_name; }
   int getRealtimeFactor() { return _realtime_factor; }
+  bool getSerialEnabled() { return _serial_enabled; }
+  int getBaudrate() { return _baudrate; }
+  std::string getDevice() { return _device; }
   void setHeadless(bool headless) { _headless = headless; }
   void setInitScriptPath(std::string path) { _init_script_path = path; }
   static void PrintHelpMessage(char* argv[]);
@@ -72,4 +75,8 @@ class ConfigurationParser {
   std::string _init_script_path;
   std::string _model_name;
   float _realtime_factor{1.0};
+  // HITL Configs
+  bool _serial_enabled{false};
+  std::string _device;
+  int _baudrate{921600};
 };

--- a/include/jsbsim_bridge.h
+++ b/include/jsbsim_bridge.h
@@ -58,6 +58,7 @@
 #include <chrono>
 
 static constexpr int kDefaultSITLTcpPort = 4560;
+static constexpr int kDefaultGCSPort = 14550;
 
 class JSBSimBridge {
  public:
@@ -67,7 +68,7 @@ class JSBSimBridge {
 
  private:
   bool SetFdmConfigs(ConfigurationParser &cfg);
-  bool SetMavlinkInterfaceConfigs(std::unique_ptr<MavlinkInterface> &interface, TiXmlHandle &config);
+  bool SetMavlinkInterfaceConfigs(std::unique_ptr<MavlinkInterface> &interface, ConfigurationParser &cfg);
 
   JSBSim::FGFDMExec *_fdmexec;  // FDMExec pointer
   ConfigurationParser &_cfg;

--- a/src/configuration_parser.cpp
+++ b/src/configuration_parser.cpp
@@ -77,7 +77,7 @@ ArgResult ConfigurationParser::ParseArgV(int argc, char* const argv[]) {
         break;
       }
       case 'b': {
-        _baudrate = std::stoi(std::string(optarg));
+        _baudrate = atoi(optarg);
         break;
       }
       case '?':

--- a/src/configuration_parser.cpp
+++ b/src/configuration_parser.cpp
@@ -56,10 +56,12 @@ bool ConfigurationParser::ParseEnvironmentVariables() {
 ArgResult ConfigurationParser::ParseArgV(int argc, char* const argv[]) {
   static const struct option options[] = {
       {"scene", required_argument, nullptr, 's'},
+      {"device", required_argument, nullptr, 'd'},
+      {"baudrate", required_argument, nullptr, 'b'},
   };
 
   int c;
-  while ((c = getopt_long(argc, argv, "s:h", options, nullptr)) >= 0) {
+  while ((c = getopt_long(argc, argv, "s:d:b:h", options, nullptr)) >= 0) {
     switch (c) {
       case 'h': {
         return ArgResult::Help;
@@ -67,6 +69,15 @@ ArgResult ConfigurationParser::ParseArgV(int argc, char* const argv[]) {
       }
       case 's': {
         _init_script_path = std::string(optarg);
+        break;
+      }
+      case 'd': {
+        _device = std::string(optarg);
+        _serial_enabled = true;
+        break;
+      }
+      case 'b': {
+        _baudrate = std::stoi(std::string(optarg));
         break;
       }
       case '?':
@@ -101,7 +112,9 @@ bool ConfigurationParser::ParseConfigFile(const std::string& path) {
 
 void ConfigurationParser::PrintHelpMessage(char* argv[]) {
   std::cout << argv[0] << " aircraft [options]\n\n"
-            << "  aircraft      Aircraft config file name e.g. rascal"
-            << "  -h | --help   Print available options\n"
-            << "  -s | --scene  Location / scene where the vehicle should be spawned in e.g. LSZH\n";
+            << "  aircraft         Aircraft config file name e.g. rascal"
+            << "  -h | --help      Print available options\n"
+            << "  -s | --scene     Location / scene where the vehicle should be spawned in e.g. LSZH\n"
+            << "  -d | --device    Device path for FMU for HITL simulation e.g. /dev/ttyACM0\n"
+            << "  -b | --baudrate  Device baudrate for FMU for HITL simulation e.g. 921600\n";
 }


### PR DESCRIPTION
**Describe problem solved by this pull request**
Currently the `px4-jsbsim-bridge` can only be used to run Software-In-The-Loop(SITL) simulations. While this is useful for evaluating the software changes in firmware, it may not reveal issues that may appear only deployed on hardware. PX4 also supports [Hardware-In-The-Loop(HITL) simulation](https://dev.px4.io/master/en/simulation/hitl.html#hardware-in-the-loop-simulation-hitl). However, this was not exposed to the jsbsim-bridge

**Describe your solution**
This commit adds configuration options for running HITL simulation with the PX4 JSBSim bridge.

The device path / baudrate can be passed with the command line when running the binary directly with flag `-d` and `-b`.
e.g.
```
HEADLESS=1 ./jsbsim_bridge rascal -d /dev/ttyACM0 -s ~/src/Firmware/Tools/jsbsim_bridge/scene/LSZH.xml
```
or to set the baudrate
```
HEADLESS=1 ./jsbsim_bridge rascal -d /dev/ttyACM0 -b 921600 -s ~/src/Firmware/Tools/jsbsim_bridge/scene/LSZH.xml
```
The bridge is configured to be run with a HITL when the device path `-d` is provided. The baudrate is configured to be `921600` by default, but can be also configured through a `-b` flag.

**Test data / coverage**
[WIP]()

**Additional context**
- Fixes https://github.com/Auterion/px4-jsbsim-bridge/issues/27
