### PR TITLE
Enable faster than realtime execution

### DIFF
--- a/include/configuration_parser.h
+++ b/include/configuration_parser.h
@@ -72,5 +72,5 @@ class ConfigurationParser {
   bool _headless{false};
   std::string _init_script_path;
   std::string _model_name;
-  int _realtime_factor{1};
+  float _realtime_factor{1.0};
 };

--- a/include/configuration_parser.h
+++ b/include/configuration_parser.h
@@ -62,6 +62,7 @@ class ConfigurationParser {
   inline std::shared_ptr<TiXmlHandle> XmlHandle() { return _config; }
   inline std::string getInitScriptPath() { return _init_script_path; }
   inline std::string getModelName() { return _model_name; }
+  inline int getRealtimeFactor() { return _realtime_factor; }
   static void PrintHelpMessage(char *argv[]);
 
  private:
@@ -71,4 +72,5 @@ class ConfigurationParser {
   bool _headless{false};
   std::string _init_script_path;
   std::string _model_name;
+  int _realtime_factor{1};
 };

--- a/include/configuration_parser.h
+++ b/include/configuration_parser.h
@@ -58,11 +58,11 @@ class ConfigurationParser {
   bool ParseEnvironmentVariables();
   bool ParseConfigFile(const std::string& path);
   ArgResult ParseArgV(int argc, char* const argv[]);
-  inline bool isHeadless() { return _headless; }
-  inline std::shared_ptr<TiXmlHandle> XmlHandle() { return _config; }
-  inline std::string getInitScriptPath() { return _init_script_path; }
-  inline std::string getModelName() { return _model_name; }
-  inline int getRealtimeFactor() { return _realtime_factor; }
+  bool isHeadless() { return _headless; }
+  std::shared_ptr<TiXmlHandle> XmlHandle() { return _config; }
+  std::string getInitScriptPath() { return _init_script_path; }
+  std::string getModelName() { return _model_name; }
+  int getRealtimeFactor() { return _realtime_factor; }
   static void PrintHelpMessage(char *argv[]);
 
  private:

--- a/include/jsbsim_bridge.h
+++ b/include/jsbsim_bridge.h
@@ -81,7 +81,7 @@ class JSBSimBridge {
   std::unique_ptr<ActuatorPlugin> _actuators;
 
   std::chrono::time_point<std::chrono::system_clock> _last_step_time;
-  double _dt;
-  bool _realtime;
-  bool _result;
+  double _dt{0.004};
+  int _realtime_factor{1};
+  bool _result{true};
 };

--- a/include/jsbsim_bridge.h
+++ b/include/jsbsim_bridge.h
@@ -80,8 +80,7 @@ class JSBSimBridge {
   std::unique_ptr<SensorAirspeedPlugin> _airspeed_sensor;
   std::unique_ptr<ActuatorPlugin> _actuators;
 
-  std::chrono::time_point<std::chrono::system_clock> _last_step_time;
   double _dt{0.004};
-  int _realtime_factor{1};
+  double _realtime_factor{1.0};
   bool _result{true};
 };

--- a/src/configuration_parser.cpp
+++ b/src/configuration_parser.cpp
@@ -46,6 +46,10 @@ bool ConfigurationParser::ParseEnvironmentVariables() {
   if (const char* headless_char = std::getenv("HEADLESS")) {
     _headless = !std::strcmp(headless_char, "1");
   }
+
+  if (const char* realtimefactor_char = std::getenv("PX4_SIM_SPEED_FACTOR")) {
+    _realtime_factor = std::stoi(realtimefactor_char);
+  }
   return true;
 }
 

--- a/src/configuration_parser.cpp
+++ b/src/configuration_parser.cpp
@@ -48,7 +48,7 @@ bool ConfigurationParser::ParseEnvironmentVariables() {
   }
 
   if (const char* realtimefactor_char = std::getenv("PX4_SIM_SPEED_FACTOR")) {
-    _realtime_factor = std::stoi(realtimefactor_char);
+    _realtime_factor = std::stod(realtimefactor_char);
   }
   return true;
 }

--- a/src/jsbsim_bridge.cpp
+++ b/src/jsbsim_bridge.cpp
@@ -90,8 +90,6 @@ JSBSimBridge::JSBSimBridge(JSBSim::FGFDMExec *fdmexec, ConfigurationParser &cfg)
   _actuators->SetActuatorConfigs(config);
 
   _realtime_factor = _cfg.getRealtimeFactor();
-
-  _last_step_time = std::chrono::system_clock::now();
 }
 
 JSBSimBridge::~JSBSimBridge() {}
@@ -170,7 +168,7 @@ bool JSBSimBridge::SetMavlinkInterfaceConfigs(std::unique_ptr<MavlinkInterface> 
 
 void JSBSimBridge::Run() {
   // Get Simulation time from JSBSim
-  auto current_time = std::chrono::system_clock::now();
+  auto step_start_time = std::chrono::system_clock::now();
   double simtime = _fdmexec->GetSimTime();
 
   // Update sensor messages
@@ -210,11 +208,11 @@ void JSBSimBridge::Run() {
 
   _result = _fdmexec->Run();
 
-  std::chrono::duration<double> elapsed_time = current_time - _last_step_time;
+  auto step_stop_time = std::chrono::system_clock::now();
+
+  std::chrono::duration<double> elapsed_time = step_start_time - step_stop_time;
   if (_realtime_factor > 0) {
     double sleep = _dt/_realtime_factor - elapsed_time.count();
     if (sleep > 0) usleep(sleep * 1e6);
   }
-
-  _last_step_time = current_time;
 }


### PR DESCRIPTION
**Problem Description**
When running Software-In-The-Loop simulations, executing the simulation faster than realtime allows quicker iterations on development. This is already utilized in PX4 SITL Gazebo and jmavsim, and the mavlink HIL Sensor messages already support it.

**Solution**
This enables setting the realtime factor with environment variable `PX4_SIM_SPEED_FACTOR` to allow faster than realtime execution of the simulation. This environment variable is already used for other simulators for faster than real time execution.

@RomanBapst Here you go!

**Testing**
To test, you can set the environment variable on execution. 
```
PX4_SIM_SPEED_FACTOR=20 make px4_sitl jsbsim
```