### PR TITLE
Improve baro drift noise and enable user XML mapping of JSBSim baro variables

### DIFF
--- a/configs/quadrotor_x.xml
+++ b/configs/quadrotor_x.xml
@@ -25,6 +25,8 @@
             <jsb_gps_satellites>px4/gps-satellites-visible</jsb_gps_satellites>
         </gps>
         <barometer>
+            <jsb_baro_temp>px4/baro-temp</jsb_baro_temp>
+            <jsb_baro_air_pressure>px4/baro-abs-pressure</jsb_baro_air_pressure>
         </barometer>
         <magnetometer>
         </magnetometer>

--- a/include/common.h
+++ b/include/common.h
@@ -47,6 +47,7 @@
 inline double ftToM(double ft) { return 0.3048 * ft; }
 inline double rankineToCelsius(double temp) { return (temp - 491.67) * 5 / 9; }
 inline double psfToBar(double pressure) { return 0.000478802588 * pressure; }
+inline double psfToMbar(double pressure) { return 0.478802588 * pressure; }
 
 inline double wrap_pi(double x) {
   while (x > M_PI) {

--- a/include/sensor_baro_plugin.h
+++ b/include/sensor_baro_plugin.h
@@ -56,10 +56,24 @@ class SensorBaroPlugin : public SensorPlugin {
   float getPressureAltitude();
   float getAirPressure();
 
+  double _abs_pressure;
+
+  void addNoise(double abs_pressure, const double dt);
+
   std::normal_distribution<double> _standard_normal_distribution;
 
   // state variables for baro pressure sensor random noise generator
   double _baro_rnd_y2{0.};
+  double _baro_mbar_rms_noise{1.};
   bool _baro_rnd_use_last{false};
-  double _baro_drift_pa{0.};
+  double _baro_drift_mbar{0.};
+  double _baro_drift_mbar_per_sec{0.};
+
+  // Variable for temperature sensor random noise
+  double _temperature_stddev{0.02};
+
+  // JSBSim default variables
+  std::string _jsb_baro_temp = "atmosphere/T-R";
+  std::string _jsb_baro_pressure_alt = "atmosphere/pressure-altitude";
+  std::string _jsb_baro_air_pressure= "atmosphere/P-psf";
 };

--- a/models/quadrotor_x/quadrotor_x.xml
+++ b/models/quadrotor_x/quadrotor_x.xml
@@ -457,4 +457,5 @@
   </aerodynamics>
   <system file="px4_default_imu_sensor"/>
   <system file="px4_default_gps_sensor"/>
+  <system file="px4_default_baro_sensor"/>
 </fdm_config>

--- a/src/sensor_baro_plugin.cpp
+++ b/src/sensor_baro_plugin.cpp
@@ -48,35 +48,69 @@ SensorBaroPlugin::SensorBaroPlugin(JSBSim::FGFDMExec* jsbsim) : SensorPlugin(jsb
 SensorBaroPlugin::~SensorBaroPlugin() {}
 
 void SensorBaroPlugin::setSensorConfigs(const TiXmlElement& configs) {
-  GetConfigElement<double>(configs, "drift_pa", _baro_drift_pa);
-  GetConfigElement<double>(configs, "rnd_y2", _baro_rnd_y2);
+  GetConfigElement<double>(configs, "baro_drift_mbar_per_sec", _baro_drift_mbar_per_sec);
+  GetConfigElement<double>(configs, "baro_mbar_rms_noise", _baro_mbar_rms_noise);
+  GetConfigElement<double>(configs, "temperature_stddev", _temperature_stddev);
+  GetConfigElement<std::string>(configs, "jsb_baro_temp", _jsb_baro_temp);
+  GetConfigElement<std::string>(configs, "jsb_baro_pressure_alt", _jsb_baro_pressure_alt);
+  GetConfigElement<std::string>(configs, "jsb_baro_air_pressure", _jsb_baro_air_pressure);
 }
 
 SensorData::Barometer SensorBaroPlugin::getData() {
   double sim_time = _sim_ptr->GetSimTime();
   double dt = sim_time - _last_sim_time;
 
-  double temperature = getAirTemperature() + 0.2 * _standard_normal_distribution(_random_generator);
-  double abs_pressure = getAirPressure() + 0.2 * _standard_normal_distribution(_random_generator);
-  double pressure_alt = getPressureAltitude() + 0.2 * _standard_normal_distribution(_random_generator);
+  double temperature = getAirTemperature() + _temperature_stddev * _standard_normal_distribution(_random_generator);
+  double pressure_alt = getPressureAltitude(); // No noise added as PX4 does not utilize this data [27 Oct 20]
+
+  _abs_pressure = getAirPressure();
 
   SensorData::Barometer data;
 
+  addNoise(_abs_pressure, dt);
+
   data.temperature = temperature;
-  data.abs_pressure = abs_pressure;
+  data.abs_pressure =_abs_pressure;
   data.pressure_alt = pressure_alt;
 
   _last_sim_time = sim_time;
   return data;
 }
 
-float SensorBaroPlugin::getAirTemperature() { return rankineToCelsius(_sim_ptr->GetPropertyValue("atmosphere/T-R")); }
+float SensorBaroPlugin::getAirTemperature() { return rankineToCelsius(_sim_ptr->GetPropertyValue(_jsb_baro_temp)); }
 
-float SensorBaroPlugin::getPressureAltitude() {
-  return ftToM(_sim_ptr->GetPropertyValue("atmosphere/pressure-altitude"));
-}
+float SensorBaroPlugin::getPressureAltitude() { return ftToM(_sim_ptr->GetPropertyValue(_jsb_baro_pressure_alt)); }
 
-float SensorBaroPlugin::getAirPressure() {
-  // calculate millibar
-  return psfToBar(_sim_ptr->GetPropertyValue("atmosphere/P-psf")) * 1000;
-}
+float SensorBaroPlugin::getAirPressure() { return psfToMbar(_sim_ptr->GetPropertyValue(_jsb_baro_air_pressure)); }
+
+void SensorBaroPlugin::addNoise(double abs_pressure, const double dt) {
+  if (dt <= 0.0) return;
+
+    // generate Gaussian noise sequence using polar form of Box-Muller transformation
+    double y1;
+    {
+      double x1, x2, w;
+      if (!_baro_rnd_use_last) {
+        do {
+          x1 = 2.0 * _standard_normal_distribution(_random_generator) - 1.0;
+          x2 = 2.0 * _standard_normal_distribution(_random_generator) - 1.0;
+          w = x1 * x1 + x2 * x2;
+        } while ( w >= 1.0 );
+        w = sqrt( (-2.0 * log( w ) ) / w );
+        // calculate two values - the second value can be used next time because it is uncorrelated
+        y1 = x1 * w;
+        _baro_rnd_y2 = x2 * w;
+        _baro_rnd_use_last = true;
+      } else {
+        // no need to repeat the calculation - use the second value from last update
+        y1 = _baro_rnd_y2;
+        _baro_rnd_use_last = false;
+      }
+    }
+
+    // Apply noise and drift
+    const float abs_pressure_noise = _baro_mbar_rms_noise * (float)y1;
+    _baro_drift_mbar += _baro_drift_mbar_per_sec * dt;
+
+    _abs_pressure = _abs_pressure + abs_pressure_noise + _baro_drift_mbar;
+  }

--- a/systems/px4_default_baro_sensor.xml
+++ b/systems/px4_default_baro_sensor.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<system name="PX4 Baro Sensor">
+<!--  =================================================================
+
+This is a generic JSBSim system file to simulate the Baro sensor behavior for PX4.
+
+  =================================================================  -->
+
+    <!-- Enable Individual Component Failure -->
+    <property value="1">px4/baro/on</property>
+    <property value="1">px4/temp/on</property>
+
+    <channel name="Abs-Pressure" execute="px4/baro/on">
+        <sensor name="px4/baro-abs-pressure">
+            <input>atmosphere/P-psf</input>
+            <lag> 0 </lag>
+            <!--Adjust as required
+            <noise variation="ABSOLUTE" distribution="GAUSSIAN"> 0.00000001 </noise>
+            <quantization name="name">
+                <bits> number </bits>
+                <min> number </min>
+                <max> number </max>
+            </quantization>
+            <drift_rate> number </drift_rate>
+            <gain> number </gain>
+            <bias> number </bias>
+            <delay [type="time|frames"]> number < /delay>
+            -->
+        </sensor>
+    </channel>
+
+    <channel name="Temperature" execute="px4/temp/on">
+        <sensor name="px4/baro-temp">
+            <input>atmosphere/T-R</input>
+            <lag> 0 </lag>
+            <!--Adjust as required
+            <noise variation="ABSOLUTE" distribution="GAUSSIAN"> 0.00000001</noise>
+            <quantization name="name">
+                <bits> number </bits>
+                <min> number </min>
+                <max> number </max>
+            </quantization>
+            <drift_rate> number </drift_rate>
+            <gain> number </gain>
+            <bias> number </bias>
+            <delay [type="time|frames"]> number < /delay>
+            -->
+        </sensor>
+    </channel>
+</system>


### PR DESCRIPTION
**Proposal** 
Improve baro sensor model by incorporating baro drift plus noise and enable user to define and select all variables affecting sensor performance via XML.

**Description of noise model change** 
Adopt similar technique as [Gazebo](https://github.com/PX4/sitl_gazebo/blob/master/src/gazebo_barometer_plugin.cpp) but modify for information available from JSBSim.

**Description of XML Mapping** 
Same as previous. Expose all parameters via XML.

**To Test**
Run  `make px4_sitl jsbsim_quadrotor_x` (or any other model).
