### PR TITLE
Enable GPS publication of COG and minor format cleanup

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -61,6 +61,13 @@ inline double wrap_pi(double x) {
   return x;
 }
 
+inline double wrap_pi_deg(double x) {
+  while (x < 0) {
+    x += 360;
+  }
+  return x;
+}
+
 inline bool CheckConfigElement(const TiXmlElement &config, std::string param) {
   const TiXmlElement *e = config.FirstChildElement(param);
   return e != nullptr;

--- a/include/sensor_gps_plugin.h
+++ b/include/sensor_gps_plugin.h
@@ -53,15 +53,15 @@ class SensorGpsPlugin : public SensorPlugin {
 
  private:
   SensorData::Gps getGpsFromJSBSim();
-  std::string jsb_gps_fix_type = "none";
-  std::string jsb_gps_lat = "position/lat-geod-deg";
-  std::string jsb_gps_lon = "position/long-gc-deg";
-  std::string jsb_gps_alt = "position/h-sl-meters";
-  std::string jsb_gps_eph = "none";
-  std::string jsb_gps_epv = "none";
-  std::string jsb_gps_v_north = "velocities/v-north-fps";
-  std::string jsb_gps_v_east = "velocities/v-east-fps";
-  std::string jsb_gps_v_down = "velocities/v-down-fps";
-  std::string jsb_gps_velocity = "velocities/ned-velocity-mag-fps";
-  std::string jsb_gps_satellites = "none";
+  std::string _jsb_gps_fix_type = "none";
+  std::string _jsb_gps_lat = "position/lat-geod-deg";
+  std::string _jsb_gps_lon = "position/long-gc-deg";
+  std::string _jsb_gps_alt = "position/h-sl-meters";
+  std::string _jsb_gps_eph = "none";
+  std::string _jsb_gps_epv = "none";
+  std::string _jsb_gps_v_north = "velocities/v-north-fps";
+  std::string _jsb_gps_v_east = "velocities/v-east-fps";
+  std::string _jsb_gps_v_down = "velocities/v-down-fps";
+  std::string _jsb_gps_velocity = "velocities/ned-velocity-mag-fps";
+  std::string _jsb_gps_satellites = "none";
 };

--- a/src/sensor_gps_plugin.cpp
+++ b/src/sensor_gps_plugin.cpp
@@ -40,23 +40,24 @@
  */
 
 #include "sensor_gps_plugin.h"
+#include "common.h"
 
 SensorGpsPlugin::SensorGpsPlugin(JSBSim::FGFDMExec* jsbsim) : SensorPlugin(jsbsim) { _update_rate = 1.0; }
 
 SensorGpsPlugin::~SensorGpsPlugin() {}
 
 void SensorGpsPlugin::setSensorConfigs(const TiXmlElement& configs) {
-    GetConfigElement<std::string>(configs, "jsb_gps_fix_type", jsb_gps_fix_type);
-    GetConfigElement<std::string>(configs, "jsb_gps_lat", jsb_gps_lat);
-    GetConfigElement<std::string>(configs, "jsb_gps_lon", jsb_gps_lon);
-    GetConfigElement<std::string>(configs, "jsb_gps_alt", jsb_gps_alt);
-    GetConfigElement<std::string>(configs, "jsb_gps_eph", jsb_gps_eph);
-    GetConfigElement<std::string>(configs, "jsb_gps_epv", jsb_gps_epv);
-    GetConfigElement<std::string>(configs, "jsb_gps_v_north", jsb_gps_v_north);
-    GetConfigElement<std::string>(configs, "jsb_gps_v_east", jsb_gps_v_east);
-    GetConfigElement<std::string>(configs, "jsb_gps_v_down", jsb_gps_v_down);
-    GetConfigElement<std::string>(configs, "jsb_gps_velocity", jsb_gps_velocity);
-    GetConfigElement<std::string>(configs, "jsb_gps_satellites", jsb_gps_satellites);
+    GetConfigElement<std::string>(configs, "jsb_gps_fix_type", _jsb_gps_fix_type);
+    GetConfigElement<std::string>(configs, "jsb_gps_lat", _jsb_gps_lat);
+    GetConfigElement<std::string>(configs, "jsb_gps_lon", _jsb_gps_lon);
+    GetConfigElement<std::string>(configs, "jsb_gps_alt", _jsb_gps_alt);
+    GetConfigElement<std::string>(configs, "jsb_gps_eph", _jsb_gps_eph);
+    GetConfigElement<std::string>(configs, "jsb_gps_epv", _jsb_gps_epv);
+    GetConfigElement<std::string>(configs, "jsb_gps_v_north", _jsb_gps_v_north);
+    GetConfigElement<std::string>(configs, "jsb_gps_v_east", _jsb_gps_v_east);
+    GetConfigElement<std::string>(configs, "jsb_gps_v_down", _jsb_gps_v_down);
+    GetConfigElement<std::string>(configs, "jsb_gps_velocity", _jsb_gps_velocity);
+    GetConfigElement<std::string>(configs, "jsb_gps_satellites", _jsb_gps_satellites);
 }
 
 SensorData::Gps SensorGpsPlugin::getData() {
@@ -75,38 +76,38 @@ SensorData::Gps SensorGpsPlugin::getGpsFromJSBSim() {
   SensorData::Gps ret;
   ret.time_utc_usec = _sim_ptr->GetSimTime() * 1e6;
 
-  if(jsb_gps_fix_type == "none") {
+  if(_jsb_gps_fix_type == "none") {
     ret.fix_type = 3;
   } else {
-      ret.fix_type = _sim_ptr->GetPropertyValue(jsb_gps_fix_type);
+      ret.fix_type = _sim_ptr->GetPropertyValue(_jsb_gps_fix_type);
   }
 
-  ret.latitude_deg = _sim_ptr->GetPropertyValue(jsb_gps_lat) * 1e7;
-  ret.longitude_deg = _sim_ptr->GetPropertyValue(jsb_gps_lon) * 1e7;
-  ret.altitude = _sim_ptr->GetPropertyValue(jsb_gps_alt) * 1e3;
-
-  if(jsb_gps_eph == "none") {
+  if(_jsb_gps_eph == "none") {
     ret.eph = 1 * 100;
   } else {
-      ret.eph = _sim_ptr->GetPropertyValue(jsb_gps_eph)*100;
+      ret.eph = _sim_ptr->GetPropertyValue(_jsb_gps_eph)*100;
   }
 
-  if(jsb_gps_epv == "none") {
+  if(_jsb_gps_epv == "none") {
     ret.epv = 2 * 100;
   } else {
-      ret.epv = _sim_ptr->GetPropertyValue(jsb_gps_epv)*100;
+      ret.epv = _sim_ptr->GetPropertyValue(_jsb_gps_epv)*100;
   }
 
-  ret.velocity_north = ftToM(_sim_ptr->GetPropertyValue(jsb_gps_v_north)) * 100;
-  ret.velocity_east = ftToM(_sim_ptr->GetPropertyValue(jsb_gps_v_east)) * 100;
-  ret.velocity_down = ftToM(_sim_ptr->GetPropertyValue(jsb_gps_v_down)) * 100;
-  ret.velocity = ftToM(_sim_ptr->GetPropertyValue(jsb_gps_velocity)) * 100;
-
-  if(jsb_gps_satellites == "none") {
+  if(_jsb_gps_satellites == "none") {
     ret.satellites_visible = 16;
   } else {
-      ret.satellites_visible = _sim_ptr->GetPropertyValue(jsb_gps_satellites);
+      ret.satellites_visible = _sim_ptr->GetPropertyValue(_jsb_gps_satellites);
   }
+
+  ret.latitude_deg = _sim_ptr->GetPropertyValue(_jsb_gps_lat) * 1e7;
+  ret.longitude_deg = _sim_ptr->GetPropertyValue(_jsb_gps_lon) * 1e7;
+  ret.altitude = _sim_ptr->GetPropertyValue(_jsb_gps_alt) * 1e3;
+  ret.velocity_north = ftToM(_sim_ptr->GetPropertyValue(_jsb_gps_v_north)) * 100;
+  ret.velocity_east = ftToM(_sim_ptr->GetPropertyValue(_jsb_gps_v_east)) * 100;
+  ret.velocity_down = ftToM(_sim_ptr->GetPropertyValue(_jsb_gps_v_down)) * 100;
+  ret.velocity = ftToM(_sim_ptr->GetPropertyValue(_jsb_gps_velocity)) * 100;
+  ret.cog = wrap_pi_deg(atan2f(ret.velocity_east,ret.velocity_north) * (180/M_PI)) * 100;
 
   ret.id = 1;
 


### PR DESCRIPTION
**Proposal**
Update GPS plugin to include COG (course over ground) using the same approach as hardware sensors [here](https://github.com/PX4/PX4-Autopilot/blob/a24488328f175e4657ad449996c42260e4da9c92/src/modules/sih/sih.cpp#L365-L366).
Previously this data was omitted and therefore always published zero.

Other changes include variable name standardization and reordering of `sensor_gps_plugin.cpp` code for readability.

**To Test**
Make with any of the existing airframes, observe GPS COG data via QGC or logs.
