### PR TITLE
Declare FGInitialCondition as shared_ptr

### DIFF
--- a/src/jsbsim_bridge.cpp
+++ b/src/jsbsim_bridge.cpp
@@ -143,7 +143,7 @@ bool JSBSimBridge::SetFdmConfigs(ConfigurationParser &cfg) {
   } else {
     _fdmexec->SetAircraftPath(SGPath(aircraft_path.c_str()));
     _fdmexec->LoadModel(aircraft_model.c_str(), false);
-    JSBSim::FGInitialCondition *initial_condition = _fdmexec->GetIC();
+    auto initial_condition = _fdmexec->GetIC();
     initial_condition->Load(SGPath(init_script_path), false);
     return true;
   }


### PR DESCRIPTION
While trying JSBSim (built from source on Linux), I got this error:
```
 error: cannot convert ‘std::shared_ptr<JSBSim::FGInitialCondition>’ to ‘JSBSim::FGInitialCondition*’ in initialization
  146 |     JSBSim::FGInitialCondition *initial_condition = _fdmexec->GetIC();
      |                                                     ~~~~~~~~~~~~~~~^~
      |                                                                    |
      |                                                                    std::shared_ptr<JSBSim::FGInitialCondition>
```
After this change I was able to run build and run a SITL test successfully.