### PR TITLE
Fix firmware build test

### DIFF
--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   Firmware-build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-simulation-focal:2020-09-14
+    container: px4io/px4-dev-simulation-focal:2021-02-04
     steps:
     - name: Checkout Firmware master
       uses: actions/checkout@v2.3.1

--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   Firmware-build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-simulation-focal:2021-02-04
+    container: px4io/px4-dev-simulation-focal:2021-05-04
     steps:
     - name: Checkout Firmware master
       uses: actions/checkout@v2.3.1


### PR DESCRIPTION
**Problem Description**
The firmware build test was broken since the px4 container seems to be now outdated for the upstream PX4-Autopilot firmware.

This PR tries to address this issue by updating the build container