### PR TITLE
Add support for HIL

### DIFF
--- a/include/configuration_parser.h
+++ b/include/configuration_parser.h
@@ -60,6 +60,9 @@ class ConfigurationParser {
   std::string getInitScriptPath() { return _init_script_path; }
   std::string getModelName() { return _model_name; }
   int getRealtimeFactor() { return _realtime_factor; }
+  bool getSerialEnabled() { return _serial_enabled; }
+  int getBaudrate() { return _baudrate; }
+  std::string getDevice() { return _device; }
   void setHeadless(bool headless) { _headless = headless; }
   void setInitScriptPath(std::string path) { _init_script_path = path; }
   static void PrintHelpMessage(char* argv[]);
@@ -72,4 +75,9 @@ class ConfigurationParser {
   std::string _init_script_path;
   std::string _model_name;
   float _realtime_factor{1.0};
+  // HITL Configs
+  bool _serial_enabled{false};
+  std::string _device;
+  int _baudrate{921600};
 };
+

--- a/include/jsbsim_bridge.h
+++ b/include/jsbsim_bridge.h
@@ -58,6 +58,7 @@
 #include <chrono>
 
 static constexpr int kDefaultSITLTcpPort = 4560;
+static constexpr int kDefaultGCSPort = 14550;
 
 class JSBSimBridge {
  public:
@@ -67,7 +68,7 @@ class JSBSimBridge {
 
  private:
   bool SetFdmConfigs(ConfigurationParser &cfg);
-  bool SetMavlinkInterfaceConfigs(std::unique_ptr<MavlinkInterface> &interface, TiXmlHandle &config);
+  bool SetMavlinkInterfaceConfigs(std::unique_ptr<MavlinkInterface> &interface, ConfigurationParser &cfg);
 
   JSBSim::FGFDMExec *_fdmexec;  // FDMExec pointer
   ConfigurationParser &_cfg;
@@ -84,3 +85,4 @@ class JSBSimBridge {
   double _realtime_factor{1.0};
   bool _result{true};
 };
+

--- a/src/configuration_parser.cpp
+++ b/src/configuration_parser.cpp
@@ -56,10 +56,12 @@ bool ConfigurationParser::ParseEnvironmentVariables() {
 ArgResult ConfigurationParser::ParseArgV(int argc, char* const argv[]) {
   static const struct option options[] = {
       {"scene", required_argument, nullptr, 's'},
+      {"device", required_argument, nullptr, 'd'},
+      {"baudrate", required_argument, nullptr, 'b'},
   };
 
   int c;
-  while ((c = getopt_long(argc, argv, "s:h", options, nullptr)) >= 0) {
+  while ((c = getopt_long(argc, argv, "s:d:b:h", options, nullptr)) >= 0) {
     switch (c) {
       case 'h': {
         return ArgResult::Help;
@@ -67,6 +69,15 @@ ArgResult ConfigurationParser::ParseArgV(int argc, char* const argv[]) {
       }
       case 's': {
         _init_script_path = std::string(optarg);
+        break;
+      }
+      case 'd': {
+        _device = std::string(optarg);
+        _serial_enabled = true;
+        break;
+      }
+      case 'b': {
+        _baudrate = atoi(optarg);
         break;
       }
       case '?':
@@ -101,7 +112,10 @@ bool ConfigurationParser::ParseConfigFile(const std::string& path) {
 
 void ConfigurationParser::PrintHelpMessage(char* argv[]) {
   std::cout << argv[0] << " aircraft [options]\n\n"
-            << "  aircraft      Aircraft config file name e.g. rascal"
-            << "  -h | --help   Print available options\n"
-            << "  -s | --scene  Location / scene where the vehicle should be spawned in e.g. LSZH\n";
+            << "  aircraft         Aircraft config file name e.g. rascal"
+            << "  -h | --help      Print available options\n"
+            << "  -s | --scene     Location / scene where the vehicle should be spawned in e.g. LSZH\n"
+            << "  -d | --device    Device path for FMU for HITL simulation e.g. /dev/ttyACM0\n"
+            << "  -b | --baudrate  Device baudrate for FMU for HITL simulation e.g. 921600\n";
 }
+


### PR DESCRIPTION
#### Describe problem solved by this pull request
With reference to PR # [28](https://github.com/Auterion/px4-jsbsim-bridge/pull/28) for enabling HITL with JSBSim bridge, this uses the modifications from that PR and further builds on it to successfully run HITL for Rascal with JSBSim Bridge. Using that PR directly resulted in [takeoff](https://github.com/Auterion/px4-jsbsim-bridge/issues/60) issues which have now been resolved. 
 #### Steps for HITL
1. Change the mixer file referenced in `1000_rc_fw_easystar.hil` to `plane_sitl.main.mix` required by rascal. 
2. Build and upload the code on hardware. Select the HILStar airframe from QGC. 
3. Build the jsbsim bridge with `make px4_sitl jsbsim`. 
4. Change the directory to the location of build of jsbsim bridge. It is usually `PX4-Autopilot/build/px4_sitl_default/build_jsbsim_bridge`. 
5. From the above directory, run the following command:
`HEADLESS=1 ./jsbsim_bridge rascal -d /dev/ttyACM0 -s ~/13.2/PX4-Autopilot/Tools/jsbsim_bridge/scene/LSZH.xml`
Where:

- rascal is the name of config file. 
- -d specifies the port of connected hardware. 
- -s specifies the path of the scene file. 
6. From QGC, upload the vehicle specific and HIL parameters provided here. 
[rascal_hitl.zip](https://github.com/Auterion/px4-jsbsim-bridge/files/10256701/rascal_hitl.zip)
7. Now simply command the vehicle through QGC as required. 
#### Testing
The method has been successfully tested on Pixhawk 4 with PX4 v1.13.2. A screenshot of the vehicle in mission mode is shown below:
![Screenshot from 2022-12-19 11-05-49](https://user-images.githubusercontent.com/109569555/208368733-12e6ef46-793f-4df1-840a-a9381787ecaa.png)
The log file is [here](https://review.px4.io/plot_app?log=6cfd8b6c-7f15-4fed-a530-377900ab2ba5).

