### PR TITLE
Added sensor_msg.id to avoid out of range error from PX4's SimulatorMavlink

### DIFF
--- a/src/mavlink_interface.cpp
+++ b/src/mavlink_interface.cpp
@@ -237,6 +237,7 @@ void MavlinkInterface::SendSensorMessages(int time_usec) {
     sensor_msg.xgyro = gyro_b_[0];
     sensor_msg.ygyro = gyro_b_[1];
     sensor_msg.zgyro = gyro_b_[2];
+    sensor_msg.id = 0;
 
     sensor_msg.fields_updated = (uint16_t)SensorSource::ACCEL | (uint16_t)SensorSource::GYRO;
 
@@ -248,6 +249,7 @@ void MavlinkInterface::SendSensorMessages(int time_usec) {
     sensor_msg.xmag = mag_b_[0];
     sensor_msg.ymag = mag_b_[1];
     sensor_msg.zmag = mag_b_[2];
+    sensor_msg.id = 0;
     sensor_msg.fields_updated = sensor_msg.fields_updated | (uint16_t)SensorSource::MAG;
 
     mag_updated_ = false;


### PR DESCRIPTION
**Problem description**

While running PX4_Autopilot (d98800521644ff2ba5d761c66a0d601016b96dac) in SITL with jsbsim, the following problem arise

![image](https://github.com/Auterion/px4-jsbsim-bridge/assets/16693415/d782c3c5-6ae0-45eb-8173-5ce158559632)

_This is originated here_
[src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp](https://github.com/PX4/PX4-Autopilot/blob/d98800521644ff2ba5d761c66a0d601016b96dac/src/modules/simulation/simulator_mavlink/SimulatorMavlink.cpp#L201)

`if (sensors.id >= ACCEL_COUNT_MAX) {
			PX4_ERR("Number of simulated accelerometer %d out of range. Max: %d", sensors.id, ACCEL_COUNT_MAX);
			return;
		if (sensors.id >= MAG_COUNT_MAX) {
			PX4_ERR("Number of simulated magnetometer %d out of range. Max: %d", sensors.id, MAG_COUNT_MAX);
			return;`

_Note_
Not sure why sensors.id is used as the max field length.

**Solution**
Added sensor_msg.id to acc, gyro and mag to avoid "Number of simulated…… xxx out of range" error from PX4's SimulatorMavlink class.