### PR TITLE
Populate sensor id for sensor message

### DIFF
--- a/src/mavlink_interface.cpp
+++ b/src/mavlink_interface.cpp
@@ -226,7 +226,7 @@ void MavlinkInterface::Load() {
 }
 
 void MavlinkInterface::SendSensorMessages(int time_usec) {
-  mavlink_hil_sensor_t sensor_msg;
+  mavlink_hil_sensor_t sensor_msg {};
 
   sensor_msg.time_usec = time_usec;
 


### PR DESCRIPTION
**Problem Description**
When trying to run jsbsim with PX4 SITL, you would get the following message.

```
ERROR [simulator_mavlink] Number of simulated accelerometer 80 out of range. Max: 3
```

**Solution**
This PR populates the sensor_id field in the HITL message.

**Additional Context**
- Fixes part of https://github.com/PX4/PX4-Autopilot/issues/24466