### PR TITLE
Add missing namespace specifier for std::string

### DIFF
--- a/include/actuator_plugin.h
+++ b/include/actuator_plugin.h
@@ -50,7 +50,7 @@
 struct ActuatorMap {
   size_t index;
   double scale;
-  string property;
+  std::string property;
 };
 
 class ActuatorPlugin {


### PR DESCRIPTION
Not sure how this worked before or when it broke, but it fails to compile (`string` not found) on Ubuntu Jammy with latest JSBSim release 1.2.3. 